### PR TITLE
Treat a failed model download as a failure

### DIFF
--- a/pranaam/base.py
+++ b/pranaam/base.py
@@ -37,6 +37,11 @@ class Base:
                 )
                 if not download_file(REPO_BASE_URL, str(model_dir), file_name):
                     logger.error("ERROR: Cannot download model data file")
+                    # Returning model_dir here announced success for a directory
+                    # with no model in it. The real cause then surfaced ~100
+                    # lines later as a keras "No file or directory found", and
+                    # the docstring below has always promised None.
+                    return None
             else:
                 logger.debug(f"Using model data from {model_dir}...")
             model_path = model_dir

--- a/pranaam/utils.py
+++ b/pranaam/utils.py
@@ -2,6 +2,7 @@
 
 import os
 import tarfile
+from http import HTTPStatus
 from pathlib import Path
 from typing import Final
 
@@ -16,6 +17,24 @@ REPO_BASE_URL: Final[str] = (
     os.environ.get("PRANAAM_MODEL_URL")
     or "https://dataverse.harvard.edu/api/access/datafile/13228210"
 )
+
+
+def _challenge_hint(response: requests.Response) -> str:
+    """Explain a bot-challenge response, which otherwise looks like a success.
+
+    Args:
+        response: The response to the model download request.
+
+    Returns:
+        A sentence naming the challenge, or a generic pointer.
+    """
+    if response.headers.get("x-amzn-waf-action"):
+        return (
+            "The host is challenging automated clients (x-amzn-waf-action), so "
+            "the model cannot be fetched from CI or a datacentre IP. Set "
+            "PRANAAM_MODEL_URL to a mirror."
+        )
+    return "Set PRANAAM_MODEL_URL to a mirror if the host is unreachable."
 
 
 def download_file(url: str, target: str, file_name: str) -> bool:
@@ -49,6 +68,17 @@ def download_file(url: str, target: str, file_name: str) -> bool:
                 REPO_BASE_URL, stream=True, allow_redirects=True, timeout=120
             )
             response.raise_for_status()
+            # raise_for_status() only fires on 4xx/5xx. Dataverse now sits
+            # behind an AWS WAF that answers automated clients with 202 and an
+            # empty body, which sails past it -- so the check has to be for the
+            # response we actually want, not merely the absence of an error.
+            if response.status_code != HTTPStatus.OK:
+                logger.error(
+                    f"Model download refused: {REPO_BASE_URL} returned "
+                    f"{response.status_code}, not 200. "
+                    f"{_challenge_hint(response)}"
+                )
+                return False
             content_length = response.headers.get("Content-Length")
             total_size = int(content_length) if content_length else None
             pbar.total = total_size
@@ -70,7 +100,18 @@ def download_file(url: str, target: str, file_name: str) -> bool:
     except requests.exceptions.RequestException as e:
         logger.error(f"Network error downloading models: {e}")
         return False
-    except (tarfile.TarError, OSError) as e:
+    except tarfile.TarError as e:
+        # A body that arrived but is not a tarball: an HTML error page, a
+        # truncated transfer, or a challenge that answered 200 with something
+        # other than the model. "File extraction error: empty file" sent the
+        # last person reading this log looking at tarfile, which is the one
+        # part that was working.
+        logger.error(
+            f"File extraction error: {e}. {REPO_BASE_URL} answered, but not "
+            f"with a readable tar archive."
+        )
+        return False
+    except OSError as e:
         logger.error(f"File extraction error: {e}")
         return False
     except Exception as e:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -132,8 +132,9 @@ class TestBase:
 
         result = TestClass.load_model_data("test_model")
 
-        # Should still return path even if download fails
-        assert result == Path("/fake/package/model")
+        # A failed download must fail here, not hand back a directory with no
+        # model in it and let the error surface as a missing .keras file.
+        assert result is None
 
     @patch("pranaam.base.files")
     @patch("pathlib.Path.exists")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,6 +31,7 @@ class TestDownloadFile:
         mock_response = Mock()
         mock_response.headers = {"Content-Length": "1000"}
         mock_response.iter_content.return_value = [b"chunk1", b"chunk2"]
+        mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
 
         mock_session_instance = Mock()
@@ -101,6 +102,7 @@ class TestDownloadFile:
         mock_response = Mock()
         mock_response.headers = {"Content-Length": "1000"}
         mock_response.iter_content.return_value = [b"chunk"]
+        mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
 
         mock_session_instance = Mock()
@@ -115,6 +117,35 @@ class TestDownloadFile:
 
     @patch("pranaam.utils.requests.Session")
     @patch("pranaam.utils._safe_extract_tar")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_waf_challenge_is_not_a_successful_download(
+        self, mock_file: Mock, mock_extract: Mock, mock_session: Mock
+    ) -> None:
+        """A 202 bot challenge with an empty body is a failure, not a download.
+
+        This is what Harvard Dataverse actually returns to a GitHub runner:
+        `HTTP 202`, `x-amzn-waf-action: challenge`, `Content-Length: 0`.
+        `raise_for_status()` does not fire on 2xx, so before this check the
+        zero-byte body was written out and treated as the model.
+        """
+        mock_response = Mock()
+        mock_response.status_code = 202
+        mock_response.headers = {
+            "Content-Length": "0",
+            "x-amzn-waf-action": "challenge",
+        }
+        mock_response.iter_content.return_value = []
+        mock_response.raise_for_status.return_value = None
+
+        mock_session_instance = Mock()
+        mock_session_instance.get.return_value = mock_response
+        mock_session.return_value.__enter__.return_value = mock_session_instance
+
+        assert download_file("http://test.com", "/tmp/target", "test_file") is False
+        mock_extract.assert_not_called()
+
+    @patch("pranaam.utils.requests.Session")
+    @patch("pranaam.utils._safe_extract_tar")
     @patch("pranaam.utils.Path")
     @patch("pranaam.utils.tqdm")
     def test_no_content_length(
@@ -124,6 +155,7 @@ class TestDownloadFile:
         mock_response = Mock()
         mock_response.headers = {}  # No Content-Length
         mock_response.iter_content.return_value = [b"chunk"]
+        mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
 
         mock_session_instance = Mock()
@@ -297,6 +329,7 @@ class TestErrorLogging:
         mock_response = Mock()
         mock_response.headers = {"Content-Length": "1000"}
         mock_response.iter_content.return_value = [b"chunk"]
+        mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
 
         mock_session_instance = Mock()


### PR DESCRIPTION
## What is broken

Harvard Dataverse now sits behind an AWS WAF that answers automated clients with a bot challenge:

```
$ curl -sSIL https://dataverse.harvard.edu/api/access/datafile/13228210
HTTP/2 202
x-amzn-waf-action: challenge
content-length: 0
```

`raise_for_status()` only fires on 4xx/5xx, so a `202` with an empty body sails through it. `pranaam/utils.py` writes the zero-byte body out, `tarfile` raises `empty file`, and `download_file` returns `False` — all correct so far. Then `pranaam/base.py` logs the error and **returns the model directory anyway**, so the first honest error arrives from tf-keras about a hundred log lines later:

```
E   OSError: No file or directory found at .../eng_and_hindi_models_v2/eng_model.keras
```

The fetch that never happened is never mentioned again. That is what makes the failure expensive to read: the CI log points at keras, which is the one part that was working.

## What this changes

1. **Check for the response we want, not the absence of an error.** A non-200 is refused, with a message naming the URL and the challenge header.
2. **`load_model_data` returns `None` when the download fails.** Its docstring has always promised `Path | None: ... or None if loading failed`, `_load_model` has always handled `None`, and `test_model_loading_failure_no_data` has always tested it. Only the producer never honoured the contract.
3. **The `tarfile.TarError` branch names the URL** that answered with something that is not a tar archive, rather than `File extraction error: empty file` alone.

Live against the real URL, the log now reads:

```
ERROR Model download refused: https://dataverse.harvard.edu/api/access/datafile/13228210
returned 202, not 200. The host is challenging automated clients (x-amzn-waf-action),
so the model cannot be fetched from CI or a datacentre IP. Set PRANAAM_MODEL_URL to a mirror.
```

## What this does *not* fix

**CI will still be red.** Dataverse still refuses the runner, so the integration tests still cannot load a model — they now say so honestly instead of pointing at keras. Making CI green needs the models served from somewhere that does not challenge datacentre IPs (a GitHub Release asset or HF Hub). That is a hosting decision, and **seven sibling repos share it** — `ethnicolr`, `ethnicolr2`, `instate`, `naamkaran`, `naampy`, `outkast` and `parsernaam` all pull from Dataverse too. pranaam is simply the first caught, because its integration tests only run on push to `main`. Worth deciding once, across all eight, rather than here.

## Note on the test changes

Three existing tests mocked a response with no `status_code`, which was harmless while nothing read it; they now set `200`. One test asserted the old behaviour in so many words — `# Should still return path even if download fails` — and is inverted here deliberately.

Local run of everything CI runs: `ruff check`, `ruff format --check`, `mypy pranaam/`, `deptry .`, and 76 unit tests, all clean.

Found by the fleet-health triage in gojiplus/py-canon.