### PR TITLE
Make documentation and CI builds hermetic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,6 @@ jobs:
       run: |
         uv run pytest -m "not integration" --tb=short -v --maxfail=5
 
-    - name: Run integration tests (main branch only)
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      run: |
-        uv run pytest -m "integration" -v --tb=short
-      timeout-minutes: 15
-      env:
-        PYTEST_TIMEOUT: 900
-
   build:
     name: Build and Validate Package
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,34 @@
+name: Model Integration
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: model-integration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test against hosted models
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+
+      - name: Install dependencies
+        run: uv sync --group test
+
+      - name: Run model integration tests
+        run: uv run pytest -m integration --tb=short -v

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,6 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
-    "sphinx.ext.intersphinx",
     "sphinx.ext.githubpages",
     "sphinx_copybutton",
     "myst_parser",
@@ -71,13 +70,6 @@ autodoc_default_options = {
     "special-members": "__init__",
     "undoc-members": True,
     "exclude-members": "__weakref__",
-}
-
-# Intersphinx mapping
-intersphinx_mapping = {
-    "python": ("https://docs.python.org/3/", None),
-    "pandas": ("https://pandas.pydata.org/docs/", None),
-    "numpy": ("https://numpy.org/doc/stable/", None),
 }
 
 # Furo theme options
@@ -120,6 +112,5 @@ copybutton_prompt_is_regexp = True
 copybutton_line_continuation_character = "\\"
 copybutton_here_doc_delimiter = "EOF"
 
-nbsphinx_execute = "auto"
+nbsphinx_execute = "never"
 nbsphinx_timeout = 300
-


### PR DESCRIPTION
## Summary

- render committed notebook outputs without executing notebooks during documentation builds
- remove network-backed intersphinx inventories so docs build without external services
- keep ordinary CI limited to deterministic unit checks
- preserve live hosted-model coverage in an explicit `Model Integration` workflow

## Validation

- `uv run pytest -m "not integration" --tb=short -v --maxfail=5` (75 passed)
- `deptry`, Ruff check/format, and mypy
- offline Sphinx build with warnings treated as errors
- wheel and sdist build plus `twine check --strict`