### PR TITLE
Verify and atomically cache model downloads

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,6 +15,8 @@ jobs:
     name: Test against hosted models
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      PRANAAM_MODEL_URL: ${{ secrets.PRANAAM_MODEL_URL }}
 
     steps:
       - uses: actions/checkout@v7
@@ -29,6 +31,9 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --group test
+
+      - name: Require model mirror
+        run: test -n "$PRANAAM_MODEL_URL"
 
       - name: Run model integration tests
         run: uv run pytest -m integration --tb=short -v

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -57,11 +57,23 @@ pip install 'pranaam[tensorflow-compat]'
 
 ## Model Downloads
 
-Models are automatically downloaded from Harvard Dataverse (306MB) and cached locally on first use. Ensure you have:
+Models are downloaded on first use and stored in the operating system's user cache
+directory. Downloads are installed only after both model files match their pinned
+SHA-256 checksums. Concurrent processes share a cache lock, and a failed refresh
+does not replace a verified cached model.
+
+The default Harvard Dataverse endpoint may challenge automated clients. To use a
+trusted mirror that serves the same model archive, set:
+
+```bash
+export PRANAAM_MODEL_URL="https://example.org/eng_and_hindi_models_v2.tar.gz"
+```
+
+Ensure you have:
 
 * Stable internet connection
 * At least 500MB free disk space
-* Unrestricted access to dataverse.harvard.edu
+* Access to the configured model host
 
 ## Verification
 
@@ -89,7 +101,10 @@ Solution: Install with `pip install 'pranaam[tensorflow-compat]'`
 
 Error: Network timeouts or download failures
 
-Solution: Check internet connection, models are large (306MB)
+Solution: Check the connection to the configured model host. If Harvard Dataverse
+returns an automated-client challenge, set `PRANAAM_MODEL_URL` to a trusted mirror.
+The mirror must contain the original model files because checksum mismatches are
+rejected.
 
 **Import Errors**
 

--- a/pranaam/base.py
+++ b/pranaam/base.py
@@ -1,9 +1,13 @@
-from importlib.resources import files
+"""Shared model-data loading support."""
+
 from pathlib import Path
 from typing import ClassVar
 
+from filelock import FileLock, Timeout
+from platformdirs import user_cache_path
+
 from .logging import get_logger
-from .utils import REPO_BASE_URL, download_file
+from .utils import SecurityError, download_file, get_model_url, verify_model_files
 
 logger = get_logger()
 
@@ -15,36 +19,57 @@ class Base:
 
     @classmethod
     def load_model_data(cls, file_name: str, latest: bool = False) -> Path | None:
-        """Load model data, downloading if necessary.
+        """Return a verified model directory, downloading it when needed.
 
         Args:
-            file_name: Name of the model file to load
-            latest: Whether to force download of latest version
+            file_name: Name of the model bundle directory
+            latest: Whether to refresh an existing cached bundle
 
         Returns:
-            Path | None: Path to the model directory, or None if loading failed
+            The model cache directory, or ``None`` when no usable bundle exists.
         """
-        model_path: Path | None = None
-        if cls.MODELFN:
-            # Use modern importlib.resources instead of deprecated pkg_resources
-            package_dir = files(__package__)
-            model_dir = Path(str(package_dir)) / cls.MODELFN
-            model_dir.mkdir(exist_ok=True)
+        if cls.MODELFN is None:
+            return None
 
-            target_file = model_dir / file_name
-            if not target_file.exists() or latest:
-                logger.debug(
-                    f"Downloading model data from the server (this is done only first time) ({model_dir})..."
-                )
-                if not download_file(REPO_BASE_URL, str(model_dir), file_name):
-                    logger.error("ERROR: Cannot download model data file")
-                    # Returning model_dir here announced success for a directory
-                    # with no model in it. The real cause then surfaced ~100
-                    # lines later as a keras "No file or directory found", and
-                    # the docstring below has always promised None.
+        model_dir = Path(user_cache_path("pranaam", ensure_exists=True)) / cls.MODELFN
+        model_dir.mkdir(parents=True, exist_ok=True)
+        target = model_dir / file_name
+        lock = FileLock(model_dir / f".{file_name}.lock", timeout=600)
+
+        try:
+            with lock:
+                cache_is_verified = False
+                if target.is_dir():
+                    try:
+                        verify_model_files(target)
+                        cache_is_verified = True
+                    except (SecurityError, OSError) as error:
+                        logger.warning(
+                            "Ignoring invalid model cache at %s: %s", target, error
+                        )
+
+                if cache_is_verified and not latest:
+                    logger.debug("Using model data from %s", model_dir)
+                    return model_dir
+
+                logger.debug("Downloading model data to %s", model_dir)
+                if download_file(get_model_url(), str(model_dir), file_name):
+                    if target.is_dir():
+                        return model_dir
+                    logger.error("Downloaded model bundle is missing %s", target)
                     return None
-            else:
-                logger.debug(f"Using model data from {model_dir}...")
-            model_path = model_dir
 
-        return model_path
+                if cache_is_verified and target.is_dir():
+                    logger.warning(
+                        "Model refresh failed; continuing with the verified cache at %s",
+                        target,
+                    )
+                    return model_dir
+
+                logger.error("Cannot download model data")
+                return None
+        except Timeout:
+            logger.error(
+                "Timed out waiting for the model cache lock at %s", lock.lock_file
+            )
+            return None

--- a/pranaam/utils.py
+++ b/pranaam/utils.py
@@ -1,7 +1,10 @@
-"""Utilities for downloading and extracting model files."""
+"""Utilities for downloading and installing model bundles."""
 
+import hashlib
 import os
+import shutil
 import tarfile
+import tempfile
 from http import HTTPStatus
 from pathlib import Path
 from typing import Final
@@ -13,144 +16,184 @@ from .logging import get_logger
 
 logger = get_logger()
 
-REPO_BASE_URL: Final[str] = (
-    os.environ.get("PRANAAM_MODEL_URL")
-    or "https://dataverse.harvard.edu/api/access/datafile/13228210"
+DEFAULT_MODEL_URL: Final[str] = (
+    "https://dataverse.harvard.edu/api/access/datafile/13228210"
 )
+MODEL_SHA256: Final[dict[str, str]] = {
+    "eng_model.keras": (
+        "2cdf998ede5d71715e3cfa084adc81de3b546597fc0257f929bd0e26b2e19202"
+    ),
+    "hin_model.keras": (
+        "e1b14656749bc63198b81275c978cea4959821e00233ebf82a773f1118e575c9"
+    ),
+}
+CHUNK_SIZE: Final[int] = 1024**2
 
 
-def _challenge_hint(response: requests.Response) -> str:
-    """Explain a bot-challenge response, which otherwise looks like a success.
-
-    Args:
-        response: The response to the model download request.
-
-    Returns:
-        A sentence naming the challenge, or a generic pointer.
-    """
-    if response.headers.get("x-amzn-waf-action"):
-        return (
-            "The host is challenging automated clients (x-amzn-waf-action), so "
-            "the model cannot be fetched from CI or a datacentre IP. Set "
-            "PRANAAM_MODEL_URL to a mirror."
-        )
-    return "Set PRANAAM_MODEL_URL to a mirror if the host is unreachable."
+def get_model_url() -> str:
+    """Return the configured model-bundle URL."""
+    return os.environ.get("PRANAAM_MODEL_URL") or DEFAULT_MODEL_URL
 
 
 def download_file(url: str, target: str, file_name: str) -> bool:
-    """Download and extract a model file from the given URL.
+    """Download, verify, and atomically install a model bundle.
 
     Args:
-        url: Base URL (not currently used, uses REPO_BASE_URL instead)
-        target: Target directory for extraction
-        file_name: Name of the file to download
+        url: URL of the model archive
+        target: Target directory for the installed bundle
+        file_name: Expected top-level directory in the archive
 
     Returns:
-        bool: True if download and extraction successful, False otherwise
+        ``True`` when a verified bundle was installed, otherwise ``False``.
     """
     target_path = Path(target)
-    file_path = target_path / f"{file_name}.tar.gz"
     try:
-        logger.info("Downloading models from dataverse...")
+        target_path.mkdir(parents=True, exist_ok=True)
+        _recover_interrupted_install(target_path, file_name)
+        with tempfile.TemporaryDirectory(
+            prefix=f".{file_name}-", dir=target_path
+        ) as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            archive_path = temporary_path / "model.tar.gz"
+            extracted_path = temporary_path / "extracted"
+            extracted_path.mkdir()
 
-        with (
-            requests.Session() as session,
-            tqdm(
-                unit="iB",
-                unit_scale=True,
-                desc=file_name,
-                ascii=True,
-                colour="cyan",
-            ) as pbar,
-            file_path.open("wb") as file_handle,
-        ):
-            response = session.get(
-                REPO_BASE_URL, stream=True, allow_redirects=True, timeout=120
-            )
-            response.raise_for_status()
-            # raise_for_status() only fires on 4xx/5xx. Dataverse now sits
-            # behind an AWS WAF that answers automated clients with 202 and an
-            # empty body, which sails past it -- so the check has to be for the
-            # response we actually want, not merely the absence of an error.
-            if response.status_code != HTTPStatus.OK:
-                logger.error(
-                    f"Model download refused: {REPO_BASE_URL} returned "
-                    f"{response.status_code}, not 200. "
-                    f"{_challenge_hint(response)}"
-                )
-                return False
-            content_length = response.headers.get("Content-Length")
-            total_size = int(content_length) if content_length else None
-            pbar.total = total_size
+            _download_archive(url, archive_path, file_name)
+            _safe_extract_tar(archive_path, extracted_path)
+            extracted_model = extracted_path / file_name
+            verify_model_files(extracted_model)
+            _install_verified_model(extracted_model, target_path, file_name)
 
-            for chunk in response.iter_content(chunk_size=1024**2):
-                if chunk:
-                    size = file_handle.write(chunk)
-                    pbar.update(size)
-        if not file_path.exists():
-            logger.error(f"Downloaded file not found at {file_path}")
-            return False
-
-        logger.info(f"Downloaded file size: {file_path.stat().st_size} bytes")
-
-        _safe_extract_tar(file_path, target_path)
-        file_path.unlink()
-        logger.info("Finished downloading models")
+        logger.info("Installed verified model bundle at %s", target_path / file_name)
         return True
-    except requests.exceptions.RequestException as e:
-        logger.error(f"Network error downloading models: {e}")
-        return False
-    except tarfile.TarError as e:
-        # A body that arrived but is not a tarball: an HTML error page, a
-        # truncated transfer, or a challenge that answered 200 with something
-        # other than the model. "File extraction error: empty file" sent the
-        # last person reading this log looking at tarfile, which is the one
-        # part that was working.
-        logger.error(
-            f"File extraction error: {e}. {REPO_BASE_URL} answered, but not "
-            f"with a readable tar archive."
+    except requests.exceptions.RequestException as error:
+        logger.error("Network error downloading models: %s", error)
+    except (SecurityError, tarfile.TarError, OSError, ValueError) as error:
+        logger.error("Model bundle validation failed: %s", error)
+    except Exception as error:
+        logger.error("Unexpected error downloading models: %s", error)
+    return False
+
+
+def _download_archive(url: str, archive_path: Path, file_name: str) -> None:
+    """Stream a complete HTTP 200 response into a temporary archive."""
+    with (
+        requests.Session() as session,
+        tqdm(
+            unit="iB",
+            unit_scale=True,
+            desc=file_name,
+            ascii=True,
+            colour="cyan",
+        ) as progress,
+        archive_path.open("wb") as archive,
+    ):
+        response = session.get(url, stream=True, allow_redirects=True, timeout=120)
+        response.raise_for_status()
+        if response.status_code != HTTPStatus.OK:
+            raise requests.HTTPError(
+                f"{url} returned {response.status_code}, not 200. "
+                f"{_challenge_hint(response)}",
+                response=response,
+            )
+
+        content_length = response.headers.get("Content-Length")
+        expected_size = int(content_length) if content_length else None
+        progress.total = expected_size
+        downloaded_size = 0
+
+        for chunk in response.iter_content(chunk_size=CHUNK_SIZE):
+            if chunk:
+                written = archive.write(chunk)
+                downloaded_size += written
+                progress.update(written)
+
+    if downloaded_size == 0:
+        raise SecurityError("Downloaded model archive is empty")
+    if expected_size is not None and downloaded_size != expected_size:
+        raise SecurityError(
+            f"Downloaded {downloaded_size} bytes; expected {expected_size}"
         )
-        return False
-    except OSError as e:
-        logger.error(f"File extraction error: {e}")
-        return False
-    except Exception as e:
-        logger.error(f"Unexpected error downloading models: {e}")
-        return False
+
+
+def _challenge_hint(response: requests.Response) -> str:
+    """Explain a bot-challenge response that otherwise looks successful."""
+    if response.headers.get("x-amzn-waf-action"):
+        return (
+            "The host challenged this client. Set PRANAAM_MODEL_URL to a "
+            "trusted mirror."
+        )
+    return "Set PRANAAM_MODEL_URL to a trusted mirror if this host is unavailable."
+
+
+def verify_model_files(model_path: Path) -> None:
+    """Verify every required model against its pinned SHA-256 digest."""
+    if not model_path.is_dir():
+        raise SecurityError(f"Downloaded archive is missing {model_path.name}")
+
+    for name, expected_digest in MODEL_SHA256.items():
+        path = model_path / name
+        if not path.is_file():
+            raise SecurityError(f"Downloaded archive is missing {name}")
+
+        digest = hashlib.sha256()
+        with path.open("rb") as model_file:
+            for chunk in iter(lambda: model_file.read(CHUNK_SIZE), b""):
+                digest.update(chunk)
+        if digest.hexdigest() != expected_digest:
+            raise SecurityError(f"Checksum mismatch for {name}")
+
+
+def _recover_interrupted_install(target: Path, file_name: str) -> None:
+    """Restore the previous bundle if a process stopped during the directory swap."""
+    installed = target / file_name
+    backup = target / f".{file_name}.previous"
+    if installed.exists():
+        _remove_path(backup)
+    elif backup.exists():
+        os.replace(backup, installed)
+
+
+def _install_verified_model(extracted: Path, target: Path, file_name: str) -> None:
+    """Swap a verified bundle into place and roll back a failed replacement."""
+    installed = target / file_name
+    backup = target / f".{file_name}.previous"
+    _remove_path(backup)
+
+    if installed.exists():
+        os.replace(installed, backup)
+    try:
+        os.replace(extracted, installed)
+    except Exception:
+        if backup.exists() and not installed.exists():
+            os.replace(backup, installed)
+        raise
+    else:
+        _remove_path(backup)
+
+
+def _remove_path(path: Path) -> None:
+    """Remove a file, link, or directory when it exists."""
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path)
 
 
 def _safe_extract_tar(tar_path: Path, extract_to: Path) -> None:
-    """Safely extract tar file preventing path traversal attacks.
-
-    Args:
-        tar_path: Path to the tar file
-        extract_to: Directory to extract to
-
-    Raises:
-        SecurityError: If path traversal attempt detected
-    """
-
-    def is_within_directory(directory: Path, target: Path) -> bool:
-        abs_directory = directory.resolve()
-        abs_target = target.resolve()
-        try:
-            abs_target.relative_to(abs_directory)
-            return True
-        except ValueError:
-            return False
-
+    """Extract a tar archive without allowing writes outside the destination."""
+    extract_root = extract_to.resolve()
     with tarfile.open(tar_path, "r:gz") as tar_file:
         for member in tar_file.getmembers():
-            member_path = extract_to / member.name
-            if not is_within_directory(extract_to, member_path):
+            member_path = (extract_to / member.name).resolve()
+            try:
+                member_path.relative_to(extract_root)
+            except ValueError as error:
                 raise SecurityError(
                     f"Attempted path traversal in tar file: {member.name}"
-                )
-
-        tar_file.extractall(extract_to)
+                ) from error
+        tar_file.extractall(extract_to, filter="data")
 
 
 class SecurityError(Exception):
-    """Raised when a security violation is detected."""
-
-    pass
+    """Raised when model-bundle validation detects unsafe or unexpected data."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ dependencies = [
   "numpy>=1.21.0",
   "requests>=2.25.0",
   "rich>=13.0.0",
+  "filelock>=3.20.0,<4.0.0",
+  "platformdirs>=4.0.0,<5.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,177 +1,172 @@
-"""Tests for base module."""
+"""Tests for model data management."""
 
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from threading import Event
+from unittest.mock import Mock, patch
 
 from pranaam.base import Base
+from pranaam.utils import SecurityError
 
 
 class TestBase:
-    """Test Base class functionality."""
+    """Test the model cache contract."""
 
-    def test_base_class_attributes(self) -> None:
-        """Test Base class has expected attributes."""
-        assert hasattr(Base, "MODELFN")
-        assert hasattr(Base, "load_model_data")
-        assert Base.MODELFN is None
+    def test_base_without_model_directory_returns_none(self) -> None:
+        """A base class without a model directory has nothing to load."""
+        assert Base.load_model_data("test_file") is None
 
-    def test_load_model_data_no_modelfn(self) -> None:
-        """Test load_model_data when MODELFN is None."""
-
-        # Create a test class without MODELFN set
-        class TestClass(Base):
-            MODELFN = None
-
-        result = TestClass.load_model_data("test_file")
-        assert result is None
-
-    @patch("pranaam.base.files")
     @patch("pranaam.base.download_file")
-    @patch("pathlib.Path.exists")
-    @patch("pathlib.Path.mkdir")
-    def test_load_model_data_success(
-        self,
-        mock_mkdir: MagicMock,
-        mock_exists: MagicMock,
-        mock_download: MagicMock,
-        mock_files: MagicMock,
+    @patch("pranaam.base.user_cache_path")
+    def test_missing_model_downloads_to_user_cache(
+        self, mock_cache: Mock, mock_download: Mock, tmp_path: Path
     ) -> None:
-        """Test successful model data loading."""
-        # Setup mocks - make files() return a string that can be used as a path
-        mock_files.return_value = "/fake/package"
+        """Models are installed in a writable user cache, not the package tree."""
+        mock_cache.return_value = tmp_path
 
-        # File doesn't exist (so download gets called)
-        mock_exists.return_value = False
-        mock_download.return_value = True
+        def install(url: str, target: str, file_name: str) -> bool:
+            (Path(target) / file_name).mkdir()
+            return True
 
-        # Create test class
-        class TestClass(Base):
-            MODELFN = "model"
-
-        result = TestClass.load_model_data("test_model", latest=False)
-
-        assert result == Path("/fake/package/model")
-        mock_mkdir.assert_called_once_with(exist_ok=True)
-        mock_download.assert_called_once()
-
-    @patch("pranaam.base.files")
-    @patch("pranaam.base.download_file")
-    @patch("pathlib.Path.exists")
-    @patch("pathlib.Path.mkdir")
-    def test_load_model_data_file_exists_no_latest(
-        self,
-        mock_mkdir: MagicMock,
-        mock_exists: MagicMock,
-        mock_download: MagicMock,
-        mock_files: MagicMock,
-    ) -> None:
-        """Test model loading when file exists and latest=False."""
-        # Setup mocks
-        mock_files.return_value = "/fake/package"
-
-        # File exists
-        mock_exists.return_value = True
-
-        class TestClass(Base):
-            MODELFN = "model"
-
-        result = TestClass.load_model_data("test_model", latest=False)
-
-        assert result == Path("/fake/package/model")
-        # Should not download since file exists and latest=False
-        mock_download.assert_not_called()
-
-    @patch("pranaam.base.files")
-    @patch("pranaam.base.download_file")
-    @patch("pathlib.Path.exists")
-    @patch("pathlib.Path.mkdir")
-    def test_load_model_data_force_latest(
-        self,
-        mock_mkdir: MagicMock,
-        mock_exists: MagicMock,
-        mock_download: MagicMock,
-        mock_files: MagicMock,
-    ) -> None:
-        """Test model loading with latest=True forces redownload."""
-        # Setup mocks
-        mock_files.return_value = "/fake/package"
-
-        mock_exists.return_value = True  # File exists
-        mock_download.return_value = True
-
-        class TestClass(Base):
-            MODELFN = "model"
-
-        result = TestClass.load_model_data("test_model", latest=True)
-
-        assert result == Path("/fake/package/model")
-        # Should download even though file exists because latest=True
-        mock_download.assert_called_once()
-
-    @patch("pranaam.base.files")
-    @patch("pranaam.base.download_file")
-    @patch("pathlib.Path.exists")
-    @patch("pathlib.Path.mkdir")
-    def test_load_model_data_download_failure(
-        self,
-        mock_mkdir: MagicMock,
-        mock_exists: MagicMock,
-        mock_download: MagicMock,
-        mock_files: MagicMock,
-    ) -> None:
-        """Test handling of download failure."""
-        # Setup mocks
-        mock_files.return_value = "/fake/package"
-
-        # File doesn't exist
-        mock_exists.return_value = False
-        mock_download.return_value = False  # Download fails
+        mock_download.side_effect = install
 
         class TestClass(Base):
             MODELFN = "model"
 
         result = TestClass.load_model_data("test_model")
 
-        # A failed download must fail here, not hand back a directory with no
-        # model in it and let the error surface as a missing .keras file.
-        assert result is None
+        assert result == tmp_path / "model"
+        mock_cache.assert_called_once_with("pranaam", ensure_exists=True)
+        mock_download.assert_called_once()
 
-    @patch("pranaam.base.files")
-    @patch("pathlib.Path.exists")
-    @patch("pathlib.Path.mkdir")
-    def test_load_model_data_creates_directory(
-        self, mock_mkdir: MagicMock, mock_exists: MagicMock, mock_files: MagicMock
+    @patch("pranaam.base.download_file")
+    @patch("pranaam.base.verify_model_files")
+    @patch("pranaam.base.user_cache_path")
+    def test_existing_model_is_reused(
+        self,
+        mock_cache: Mock,
+        mock_verify: Mock,
+        mock_download: Mock,
+        tmp_path: Path,
     ) -> None:
-        """Test that model directory is created if it doesn't exist."""
-        # Setup mocks
-        mock_files.return_value = "/fake/package"
-
-        mock_exists.return_value = False  # File doesn't exist
+        """An existing pinned model is reused by default."""
+        mock_cache.return_value = tmp_path
+        (tmp_path / "model" / "test_model").mkdir(parents=True)
 
         class TestClass(Base):
             MODELFN = "model"
 
-        with patch("pranaam.base.download_file", return_value=True):
-            result = TestClass.load_model_data("test_model")
+        assert TestClass.load_model_data("test_model") == tmp_path / "model"
+        mock_verify.assert_called_once_with(tmp_path / "model" / "test_model")
+        mock_download.assert_not_called()
 
-        mock_mkdir.assert_called_once_with(exist_ok=True)
-        assert result == Path("/fake/package/model")
+    @patch("pranaam.base.download_file", return_value=False)
+    @patch("pranaam.base.verify_model_files")
+    @patch("pranaam.base.user_cache_path")
+    def test_failed_refresh_preserves_verified_cache(
+        self,
+        mock_cache: Mock,
+        mock_verify: Mock,
+        mock_download: Mock,
+        tmp_path: Path,
+    ) -> None:
+        """A failed forced refresh keeps serving the existing bundle."""
+        mock_cache.return_value = tmp_path
+        cached_model = tmp_path / "model" / "test_model"
+        cached_model.mkdir(parents=True)
+
+        class TestClass(Base):
+            MODELFN = "model"
+
+        assert TestClass.load_model_data("test_model", latest=True) == (
+            tmp_path / "model"
+        )
+        assert cached_model.is_dir()
+        mock_verify.assert_called_once_with(cached_model)
+        mock_download.assert_called_once()
+
+    @patch("pranaam.base.download_file", return_value=False)
+    @patch(
+        "pranaam.base.verify_model_files",
+        side_effect=SecurityError("checksum mismatch"),
+    )
+    @patch("pranaam.base.user_cache_path")
+    def test_invalid_cache_is_not_used_when_refresh_fails(
+        self,
+        mock_cache: Mock,
+        mock_verify: Mock,
+        mock_download: Mock,
+        tmp_path: Path,
+    ) -> None:
+        """A corrupt cache is never returned as a fallback."""
+        mock_cache.return_value = tmp_path
+        cached_model = tmp_path / "model" / "test_model"
+        cached_model.mkdir(parents=True)
+
+        class TestClass(Base):
+            MODELFN = "model"
+
+        assert TestClass.load_model_data("test_model") is None
+        mock_verify.assert_called_once_with(cached_model)
+        mock_download.assert_called_once()
+
+    @patch("pranaam.base.download_file", return_value=False)
+    @patch("pranaam.base.user_cache_path")
+    def test_download_failure_without_cache_returns_none(
+        self, mock_cache: Mock, mock_download: Mock, tmp_path: Path
+    ) -> None:
+        """A failed first download cannot masquerade as a usable model path."""
+        mock_cache.return_value = tmp_path
+
+        class TestClass(Base):
+            MODELFN = "model"
+
+        assert TestClass.load_model_data("test_model") is None
+        mock_download.assert_called_once()
+
+    @patch("pranaam.base.download_file")
+    @patch("pranaam.base.verify_model_files")
+    @patch("pranaam.base.user_cache_path")
+    def test_concurrent_cache_misses_download_once(
+        self,
+        mock_cache: Mock,
+        mock_verify: Mock,
+        mock_download: Mock,
+        tmp_path: Path,
+    ) -> None:
+        """The cache lock serializes concurrent first-time downloads."""
+        mock_cache.return_value = tmp_path
+        downloading = Event()
+        release_download = Event()
+
+        def install(url: str, target: str, file_name: str) -> bool:
+            downloading.set()
+            assert release_download.wait(timeout=2)
+            (Path(target) / file_name).mkdir()
+            return True
+
+        mock_download.side_effect = install
+
+        class TestClass(Base):
+            MODELFN = "model"
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first = executor.submit(TestClass.load_model_data, "test_model")
+            assert downloading.wait(timeout=2)
+            second = executor.submit(TestClass.load_model_data, "test_model")
+            release_download.set()
+            assert first.result(timeout=2) == tmp_path / "model"
+            assert second.result(timeout=2) == tmp_path / "model"
+
+        mock_download.assert_called_once()
+        mock_verify.assert_called_once_with(tmp_path / "model" / "test_model")
 
 
 class TestBaseInheritance:
-    """Test Base class inheritance patterns."""
+    """Test class-level model directory configuration."""
 
-    def test_subclass_can_override_modelfn(self) -> None:
-        """Test that subclasses can override MODELFN."""
-
-        class CustomBase(Base):
-            MODELFN = "custom_model"
-
-        assert CustomBase.MODELFN == "custom_model"
-        assert Base.MODELFN is None  # Original unchanged
-
-    def test_multiple_subclasses_independent(self) -> None:
-        """Test that multiple subclasses have independent MODELFN values."""
+    def test_subclasses_keep_independent_model_directories(self) -> None:
+        """Changing one subclass does not mutate the base or a sibling."""
 
         class BaseA(Base):
             MODELFN = "model_a"
@@ -179,99 +174,6 @@ class TestBaseInheritance:
         class BaseB(Base):
             MODELFN = "model_b"
 
+        assert Base.MODELFN is None
         assert BaseA.MODELFN == "model_a"
         assert BaseB.MODELFN == "model_b"
-        assert Base.MODELFN is None
-
-
-class TestBaseLogging:
-    """Test logging in Base class."""
-
-    @patch("pranaam.base.logger")
-    @patch("pranaam.base.files")
-    @patch("pranaam.base.download_file")
-    @patch("pathlib.Path.exists")
-    @patch("pathlib.Path.mkdir")
-    def test_debug_logging_download(
-        self,
-        mock_mkdir: MagicMock,
-        mock_exists: MagicMock,
-        mock_download: MagicMock,
-        mock_files: MagicMock,
-        mock_logger: MagicMock,
-    ) -> None:
-        """Test debug logging during download."""
-        # Setup mocks
-        mock_files.return_value = "/fake/package"
-
-        # File doesn't exist
-        mock_exists.return_value = False
-        mock_download.return_value = True
-
-        class TestClass(Base):
-            MODELFN = "model"
-
-        TestClass.load_model_data("test_model")
-
-        # Should log download message
-        mock_logger.debug.assert_called()
-        debug_calls = [call[0][0] for call in mock_logger.debug.call_args_list]
-        assert any("Downloading model data" in call for call in debug_calls)
-
-    @patch("pranaam.base.logger")
-    @patch("pranaam.base.files")
-    @patch("pathlib.Path.exists")
-    @patch("pathlib.Path.mkdir")
-    def test_debug_logging_existing_model(
-        self,
-        mock_mkdir: MagicMock,
-        mock_exists: MagicMock,
-        mock_files: MagicMock,
-        mock_logger: MagicMock,
-    ) -> None:
-        """Test debug logging when using existing model."""
-        # Setup mocks
-        mock_files.return_value = "/fake/package"
-
-        mock_exists.return_value = True  # File exists
-
-        class TestClass(Base):
-            MODELFN = "model"
-
-        TestClass.load_model_data("test_model")
-
-        # Should log using existing model message
-        mock_logger.debug.assert_called()
-        debug_calls = [call[0][0] for call in mock_logger.debug.call_args_list]
-        assert any("Using model data from" in call for call in debug_calls)
-
-    @patch("pranaam.base.logger")
-    @patch("pranaam.base.files")
-    @patch("pranaam.base.download_file")
-    @patch("pathlib.Path.exists")
-    @patch("pathlib.Path.mkdir")
-    def test_error_logging_download_failure(
-        self,
-        mock_mkdir: MagicMock,
-        mock_exists: MagicMock,
-        mock_download: MagicMock,
-        mock_files: MagicMock,
-        mock_logger: MagicMock,
-    ) -> None:
-        """Test error logging when download fails."""
-        # Setup mocks
-        mock_files.return_value = "/fake/package"
-
-        # File doesn't exist
-        mock_exists.return_value = False
-        mock_download.return_value = False  # Download fails
-
-        class TestClass(Base):
-            MODELFN = "model"
-
-        TestClass.load_model_data("test_model")
-
-        # Should log error message
-        mock_logger.error.assert_called_once_with(
-            "ERROR: Cannot download model data file"
-        )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -18,15 +18,11 @@ class TestRealModelDownloadAndPrediction:
     @pytest.fixture(autouse=True)
     def setup_clean_environment(self) -> Generator[None, None, None]:
         """Ensure clean model state for each test."""
-        # Reset class state
-        Naam.model = None
-        Naam.weights_loaded = False
-        Naam.cur_lang = None  # type: ignore
+        with Naam._model_lock:
+            Naam._models.clear()
         yield
-        # Cleanup after test
-        Naam.model = None
-        Naam.weights_loaded = False
-        Naam.cur_lang = None  # type: ignore
+        with Naam._model_lock:
+            Naam._models.clear()
 
     @pytest.mark.integration
     def test_real_english_predictions(self) -> None:
@@ -117,13 +113,11 @@ class TestRealModelDownloadAndPrediction:
         """Test that models are properly cached after first download."""
         # First prediction - should trigger download
         result1 = pranaam.pred_rel("Shah Rukh Khan", lang="eng")
-        assert Naam.weights_loaded is True
-        assert Naam.cur_lang == "eng"
+        english_model = Naam._models["eng"]
 
         # Second prediction - should use cached model
         result2 = pranaam.pred_rel("Amitabh Bachchan", lang="eng")
-        assert Naam.weights_loaded is True
-        assert Naam.cur_lang == "eng"
+        assert Naam._models["eng"] is english_model
 
         # Results should be consistent
         assert result1.columns.tolist() == result2.columns.tolist()
@@ -135,15 +129,15 @@ class TestRealModelDownloadAndPrediction:
         """Test switching between English and Hindi models."""
         # Start with English
         eng_result = pranaam.pred_rel("Shah Rukh Khan", lang="eng")
-        assert Naam.cur_lang == "eng"
+        english_model = Naam._models["eng"]
 
-        # Switch to Hindi - should reload model
+        # Load Hindi without replacing English
         hin_result = pranaam.pred_rel("शाहरुख खान", lang="hin")
-        assert Naam.cur_lang == "hin"
+        assert set(Naam._models) == {"eng", "hin"}
 
-        # Switch back to English - should reload model again
+        # Switch back to English and reuse the cached English model
         eng_result2 = pranaam.pred_rel("Salman Khan", lang="eng")
-        assert Naam.cur_lang == "eng"
+        assert Naam._models["eng"] is english_model
 
         # All results should have same structure
         for result in [eng_result, hin_result, eng_result2]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,349 +1,276 @@
-"""Tests for utils module."""
+"""Tests for secure model downloading and extraction."""
 
+from __future__ import annotations
+
+import hashlib
+import io
 import os
 import tarfile
-import tempfile
-from pathlib import Path
-from unittest.mock import MagicMock, Mock, mock_open, patch
+from typing import TYPE_CHECKING
+from unittest.mock import Mock, patch
 
 import pytest
 import requests
 
-from pranaam.utils import REPO_BASE_URL, _safe_extract_tar, download_file
+from pranaam.utils import (
+    SecurityError,
+    _install_verified_model,
+    _safe_extract_tar,
+    download_file,
+    get_model_url,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+MODEL_URL = "https://example.test/model"
+
+
+def _archive_bytes(files: dict[str, bytes]) -> bytes:
+    stream = io.BytesIO()
+    with tarfile.open(fileobj=stream, mode="w:gz") as archive:
+        for name, content in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(content)
+            archive.addfile(info, io.BytesIO(content))
+    return stream.getvalue()
+
+
+def _session_for(
+    payload: bytes, *, status_code: int = 200, content_length: int | None = None
+) -> Mock:
+    response = Mock()
+    response.status_code = status_code
+    response.headers = {
+        "Content-Length": str(
+            len(payload) if content_length is None else content_length
+        )
+    }
+    response.iter_content.return_value = [payload]
+    response.raise_for_status.return_value = None
+    session = Mock()
+    session.get.return_value = response
+    context = Mock()
+    context.__enter__ = Mock(return_value=session)
+    context.__exit__ = Mock(return_value=False)
+    return context
+
+
+def _checksums(english: bytes = b"english", hindi: bytes = b"hindi") -> dict[str, str]:
+    return {
+        "eng_model.keras": hashlib.sha256(english).hexdigest(),
+        "hin_model.keras": hashlib.sha256(hindi).hexdigest(),
+    }
 
 
 class TestDownloadFile:
-    """Test download_file function."""
+    """Test verified, atomic model installation."""
 
     @patch("pranaam.utils.requests.Session")
-    @patch("pranaam.utils._safe_extract_tar")
-    @patch("pranaam.utils.Path")
-    @patch("pranaam.utils.tqdm")
-    def test_successful_download(
-        self,
-        mock_tqdm: Mock,
-        mock_path: Mock,
-        mock_extract: Mock,
-        mock_session: Mock,
+    def test_download_uses_argument_and_verifies_models(
+        self, mock_session: Mock, tmp_path: Path
     ) -> None:
-        """Test successful file download and extraction."""
-        # Setup mocks
-        mock_response = Mock()
-        mock_response.headers = {"Content-Length": "1000"}
-        mock_response.iter_content.return_value = [b"chunk1", b"chunk2"]
-        mock_response.status_code = 200
-        mock_response.raise_for_status.return_value = None
+        """The requested URL is used and verified files are installed."""
+        payload = _archive_bytes(
+            {
+                "bundle/eng_model.keras": b"english",
+                "bundle/hin_model.keras": b"hindi",
+            }
+        )
+        mock_session.return_value = _session_for(payload)
 
-        mock_session_instance = Mock()
-        mock_session_instance.get.return_value = mock_response
-        mock_session.return_value.__enter__.return_value = mock_session_instance
+        with patch("pranaam.utils.MODEL_SHA256", _checksums()):
+            assert download_file(MODEL_URL, str(tmp_path), "bundle")
 
-        # Mock tqdm context manager
-        mock_tqdm.return_value.__enter__.return_value.update = Mock()
+        request = mock_session.return_value.__enter__.return_value.get
+        request.assert_called_once_with(
+            MODEL_URL,
+            stream=True,
+            allow_redirects=True,
+            timeout=120,
+        )
+        assert (tmp_path / "bundle" / "eng_model.keras").read_bytes() == b"english"
+        assert not (tmp_path / ".bundle.previous").exists()
+        assert not list(tmp_path.glob(".bundle-*"))
 
-        # Mock Path operations
-        mock_file_path = MagicMock()
-        mock_target_path = MagicMock()
-        mock_path.side_effect = [mock_target_path, mock_file_path]
-        mock_target_path.__truediv__.return_value = mock_file_path
-        mock_file_path.open.return_value.__enter__.return_value = Mock()
-        mock_file_path.open.return_value.__exit__.return_value = None
-        mock_file_path.unlink.return_value = None
+    @patch("pranaam.utils.requests.Session")
+    def test_verified_refresh_replaces_old_cache(
+        self, mock_session: Mock, tmp_path: Path
+    ) -> None:
+        """A verified refresh replaces the previous bundle completely."""
+        installed = tmp_path / "bundle"
+        installed.mkdir()
+        (installed / "old.txt").write_text("old")
+        payload = _archive_bytes(
+            {
+                "bundle/eng_model.keras": b"english",
+                "bundle/hin_model.keras": b"hindi",
+            }
+        )
+        mock_session.return_value = _session_for(payload)
 
-        # Mock the extract function to not do anything
-        mock_extract.return_value = None
+        with patch("pranaam.utils.MODEL_SHA256", _checksums()):
+            assert download_file(MODEL_URL, str(tmp_path), "bundle")
 
-        # Call function
-        result = download_file("http://test.com", "/tmp/target", "test_file")
+        assert not (installed / "old.txt").exists()
+        assert (installed / "hin_model.keras").read_bytes() == b"hindi"
+        assert not (tmp_path / ".bundle.previous").exists()
 
-        # Verify
-        assert result is True
-        mock_session_instance.get.assert_called_once_with(
-            REPO_BASE_URL, stream=True, allow_redirects=True, timeout=120
+    @patch("pranaam.utils.requests.Session")
+    def test_checksum_mismatch_preserves_old_cache(
+        self, mock_session: Mock, tmp_path: Path
+    ) -> None:
+        """Unverified model bytes never replace a known-good cache."""
+        installed = tmp_path / "bundle"
+        installed.mkdir()
+        (installed / "known-good").write_bytes(b"old")
+        payload = _archive_bytes(
+            {
+                "bundle/eng_model.keras": b"wrong",
+                "bundle/hin_model.keras": b"wrong",
+            }
+        )
+        mock_session.return_value = _session_for(payload)
+
+        assert not download_file(MODEL_URL, str(tmp_path), "bundle")
+        assert (installed / "known-good").read_bytes() == b"old"
+        assert not list(tmp_path.glob(".bundle-*"))
+
+    @patch("pranaam.utils.requests.Session")
+    def test_truncated_response_preserves_old_cache(
+        self, mock_session: Mock, tmp_path: Path
+    ) -> None:
+        """A short response cannot replace an installed bundle."""
+        installed = tmp_path / "bundle"
+        installed.mkdir()
+        (installed / "known-good").write_bytes(b"old")
+        payload = _archive_bytes(
+            {
+                "bundle/eng_model.keras": b"english",
+                "bundle/hin_model.keras": b"hindi",
+            }
+        )
+        mock_session.return_value = _session_for(
+            payload, content_length=len(payload) + 100
         )
 
-    @patch("pranaam.utils.requests.Session")
-    def test_network_error(self, mock_session: Mock) -> None:
-        """Test handling of network errors."""
-        mock_session_instance = Mock()
-        mock_session_instance.get.side_effect = requests.exceptions.ConnectionError(
-            "Network error"
-        )
-        mock_session.return_value.__enter__.return_value = mock_session_instance
+        with patch("pranaam.utils.MODEL_SHA256", _checksums()):
+            assert not download_file(MODEL_URL, str(tmp_path), "bundle")
 
-        result = download_file("http://test.com", "/tmp/target", "test_file")
-
-        assert result is False
+        assert (installed / "known-good").read_bytes() == b"old"
 
     @patch("pranaam.utils.requests.Session")
-    def test_http_error(self, mock_session: Mock) -> None:
-        """Test handling of HTTP errors."""
-        mock_response = Mock()
-        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
-            "404 Not Found"
-        )
-
-        mock_session_instance = Mock()
-        mock_session_instance.get.return_value = mock_response
-        mock_session.return_value.__enter__.return_value = mock_session_instance
-
-        result = download_file("http://test.com", "/tmp/target", "test_file")
-
-        assert result is False
-
-    @patch("pranaam.utils.requests.Session")
-    @patch("pranaam.utils._safe_extract_tar")
-    @patch("builtins.open", new_callable=mock_open)
-    def test_extraction_error(
-        self, mock_file: Mock, mock_extract: Mock, mock_session: Mock
+    def test_waf_challenge_is_not_a_download(
+        self, mock_session: Mock, tmp_path: Path
     ) -> None:
-        """Test handling of extraction errors."""
-        # Setup successful download but failed extraction
-        mock_response = Mock()
-        mock_response.headers = {"Content-Length": "1000"}
-        mock_response.iter_content.return_value = [b"chunk"]
-        mock_response.status_code = 200
-        mock_response.raise_for_status.return_value = None
+        """An HTTP 202 challenge is a failure even though it is a 2xx response."""
+        context = _session_for(b"", status_code=202)
+        response = context.__enter__.return_value.get.return_value
+        response.headers["x-amzn-waf-action"] = "challenge"
+        mock_session.return_value = context
 
-        mock_session_instance = Mock()
-        mock_session_instance.get.return_value = mock_response
-        mock_session.return_value.__enter__.return_value = mock_session_instance
-
-        mock_extract.side_effect = tarfile.TarError("Corrupted tar file")
-
-        result = download_file("http://test.com", "/tmp/target", "test_file")
-
-        assert result is False
+        assert not download_file(MODEL_URL, str(tmp_path), "bundle")
+        assert not (tmp_path / "bundle").exists()
 
     @patch("pranaam.utils.requests.Session")
-    @patch("pranaam.utils._safe_extract_tar")
-    @patch("builtins.open", new_callable=mock_open)
-    def test_waf_challenge_is_not_a_successful_download(
-        self, mock_file: Mock, mock_extract: Mock, mock_session: Mock
+    def test_network_error_restores_interrupted_backup(
+        self, mock_session: Mock, tmp_path: Path
     ) -> None:
-        """A 202 bot challenge with an empty body is a failure, not a download.
+        """A cache left mid-swap is restored before attempting a new download."""
+        backup = tmp_path / ".bundle.previous"
+        backup.mkdir()
+        (backup / "known-good").write_bytes(b"old")
+        session = Mock()
+        session.get.side_effect = requests.ConnectionError("offline")
+        context = Mock()
+        context.__enter__ = Mock(return_value=session)
+        context.__exit__ = Mock(return_value=False)
+        mock_session.return_value = context
 
-        This is what Harvard Dataverse actually returns to a GitHub runner:
-        `HTTP 202`, `x-amzn-waf-action: challenge`, `Content-Length: 0`.
-        `raise_for_status()` does not fire on 2xx, so before this check the
-        zero-byte body was written out and treated as the model.
-        """
-        mock_response = Mock()
-        mock_response.status_code = 202
-        mock_response.headers = {
-            "Content-Length": "0",
-            "x-amzn-waf-action": "challenge",
-        }
-        mock_response.iter_content.return_value = []
-        mock_response.raise_for_status.return_value = None
+        assert not download_file(MODEL_URL, str(tmp_path), "bundle")
+        assert (tmp_path / "bundle" / "known-good").read_bytes() == b"old"
+        assert not backup.exists()
 
-        mock_session_instance = Mock()
-        mock_session_instance.get.return_value = mock_response
-        mock_session.return_value.__enter__.return_value = mock_session_instance
+    def test_failed_directory_swap_restores_old_cache(self, tmp_path: Path) -> None:
+        """An installation error rolls the previous directory back into place."""
+        installed = tmp_path / "bundle"
+        installed.mkdir()
+        (installed / "known-good").write_bytes(b"old")
+        extracted = tmp_path / "staging" / "bundle"
+        extracted.mkdir(parents=True)
+        (extracted / "new").write_bytes(b"new")
+        real_replace = os.replace
 
-        assert download_file("http://test.com", "/tmp/target", "test_file") is False
-        mock_extract.assert_not_called()
+        def fail_new_install(
+            source: os.PathLike[str], destination: os.PathLike[str]
+        ) -> None:
+            if source == extracted and destination == installed:
+                raise OSError("simulated swap failure")
+            real_replace(source, destination)
 
-    @patch("pranaam.utils.requests.Session")
-    @patch("pranaam.utils._safe_extract_tar")
-    @patch("pranaam.utils.Path")
-    @patch("pranaam.utils.tqdm")
-    def test_no_content_length(
-        self, mock_tqdm: Mock, mock_path: Mock, mock_extract: Mock, mock_session: Mock
+        with (
+            patch("pranaam.utils.os.replace", side_effect=fail_new_install),
+            pytest.raises(OSError, match="simulated swap failure"),
+        ):
+            _install_verified_model(extracted, tmp_path, "bundle")
+
+        assert (installed / "known-good").read_bytes() == b"old"
+        assert not (tmp_path / ".bundle.previous").exists()
+
+    def test_model_url_is_read_when_requested(
+        self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test handling when Content-Length header is missing."""
-        mock_response = Mock()
-        mock_response.headers = {}  # No Content-Length
-        mock_response.iter_content.return_value = [b"chunk"]
-        mock_response.status_code = 200
-        mock_response.raise_for_status.return_value = None
+        """A runtime environment override selects a trusted mirror."""
+        monkeypatch.setenv("PRANAAM_MODEL_URL", MODEL_URL)
 
-        mock_session_instance = Mock()
-        mock_session_instance.get.return_value = mock_response
-        mock_session.return_value.__enter__.return_value = mock_session_instance
+        assert get_model_url() == MODEL_URL
 
-        # Mock tqdm context manager
-        mock_tqdm.return_value.__enter__.return_value.update = Mock()
+    def test_empty_model_url_override_uses_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unset repository secret does not produce an invalid empty URL."""
+        monkeypatch.setenv("PRANAAM_MODEL_URL", "")
 
-        # Mock Path operations
-        mock_file_path = MagicMock()
-        mock_target_path = MagicMock()
-        mock_path.side_effect = [mock_target_path, mock_file_path]
-        mock_target_path.__truediv__.return_value = mock_file_path
-        mock_file_path.open.return_value.__enter__.return_value = Mock()
-        mock_file_path.open.return_value.__exit__.return_value = None
-        mock_file_path.unlink.return_value = None
-
-        # Mock the extract function to not do anything
-        mock_extract.return_value = None
-
-        result = download_file("http://test.com", "/tmp/target", "test_file")
-
-        assert result is True
+        assert get_model_url().startswith("https://dataverse.harvard.edu/")
 
 
 class TestSafeExtractTar:
-    """Test _safe_extract_tar function."""
+    """Test archive extraction boundaries."""
 
-    def test_safe_extraction(self) -> None:
-        """Test safe extraction of tar file."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # Create a test tar file
-            tar_path = os.path.join(temp_dir, "test.tar.gz")
-            test_file_path = os.path.join(temp_dir, "test.txt")
+    def test_safe_extraction(self, tmp_path: Path) -> None:
+        """Ordinary data files extract successfully."""
+        archive_path = tmp_path / "safe.tar.gz"
+        archive_path.write_bytes(_archive_bytes({"model/file.txt": b"content"}))
+        target = tmp_path / "target"
 
-            # Create test content
-            with open(test_file_path, "w") as f:
-                f.write("test content")
+        _safe_extract_tar(archive_path, target)
 
-            # Create tar file
-            with tarfile.open(tar_path, "w:gz") as tar:
-                tar.add(test_file_path, arcname="test.txt")
+        assert (target / "model" / "file.txt").read_bytes() == b"content"
 
-            # Remove original file
-            os.remove(test_file_path)
+    def test_path_traversal_is_rejected(self, tmp_path: Path) -> None:
+        """Parent-directory paths cannot escape the destination."""
+        archive_path = tmp_path / "traversal.tar.gz"
+        archive_path.write_bytes(_archive_bytes({"../../../outside.txt": b"bad"}))
 
-            # Extract using our function
-            extract_dir = os.path.join(temp_dir, "extracted")
-            os.makedirs(extract_dir)
+        with pytest.raises(SecurityError, match="path traversal"):
+            _safe_extract_tar(archive_path, tmp_path / "target")
 
-            _safe_extract_tar(Path(tar_path), Path(extract_dir))
+    def test_outside_symlink_is_rejected(self, tmp_path: Path) -> None:
+        """The data filter rejects links outside the destination."""
+        archive_path = tmp_path / "link.tar.gz"
+        with tarfile.open(archive_path, "w:gz") as archive:
+            info = tarfile.TarInfo("link")
+            info.type = tarfile.SYMTYPE
+            info.linkname = "../../outside"
+            archive.addfile(info)
 
-            # Verify extraction
-            extracted_file = os.path.join(extract_dir, "test.txt")
-            assert os.path.exists(extracted_file)
+        with pytest.raises(tarfile.FilterError):
+            _safe_extract_tar(archive_path, tmp_path / "target")
 
-            with open(extracted_file) as f:
-                assert f.read() == "test content"
+    def test_corrupted_archive_is_rejected(self, tmp_path: Path) -> None:
+        """Invalid archive bytes raise a tar error."""
+        archive_path = tmp_path / "corrupt.tar.gz"
+        archive_path.write_bytes(b"not a tar archive")
 
-    def test_path_traversal_prevention(self) -> None:
-        """Test prevention of path traversal attacks."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            tar_path = os.path.join(temp_dir, "malicious.tar.gz")
-
-            # Create a tar file with path traversal attempt
-            with tarfile.open(tar_path, "w:gz") as tar:
-                # Create a TarInfo object with malicious path
-                info = tarfile.TarInfo(name="../../../malicious.txt")
-                content = b"malicious content"
-                info.size = len(content)
-                # Create a temporary file with the actual content
-                import io
-
-                tar.addfile(info, fileobj=io.BytesIO(content))
-
-            extract_dir = os.path.join(temp_dir, "extracted")
-            os.makedirs(extract_dir)
-
-            # Should raise exception
-            with pytest.raises(Exception, match="Attempted path traversal"):
-                _safe_extract_tar(Path(tar_path), Path(extract_dir))
-
-    def test_corrupted_tar_file(self) -> None:
-        """Test handling of corrupted tar files."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # Create a corrupted file (not a valid tar)
-            tar_path = os.path.join(temp_dir, "corrupted.tar.gz")
-            with open(tar_path, "wb") as f:
-                f.write(b"not a tar file")
-
-            extract_dir = os.path.join(temp_dir, "extracted")
-            os.makedirs(extract_dir)
-
-            with pytest.raises(tarfile.TarError):
-                _safe_extract_tar(Path(tar_path), Path(extract_dir))
-
-    def test_nonexistent_tar_file(self) -> None:
-        """Test handling of non-existent tar file."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            tar_path = os.path.join(temp_dir, "nonexistent.tar.gz")
-            extract_dir = os.path.join(temp_dir, "extracted")
-            os.makedirs(extract_dir)
-
-            with pytest.raises((FileNotFoundError, tarfile.TarError)):
-                _safe_extract_tar(Path(tar_path), Path(extract_dir))
-
-
-class TestConstants:
-    """Test module constants."""
-
-    def test_repo_base_url_default(self) -> None:
-        """Test default repository base URL."""
-        # Should have default Harvard Dataverse URL
-        assert "dataverse.harvard.edu" in REPO_BASE_URL
-
-    @patch.dict(os.environ, {"PRANAAM_MODEL_URL": "http://custom.url/model"})
-    def test_repo_base_url_custom(self) -> None:
-        """Test custom repository URL from environment."""
-        # Need to reimport to pick up environment variable
-        import importlib
-
-        import pranaam.utils
-
-        importlib.reload(pranaam.utils)
-
-        assert pranaam.utils.REPO_BASE_URL == "http://custom.url/model"
-
-
-class TestErrorLogging:
-    """Test error logging in utils functions."""
-
-    @patch("pranaam.utils.logger")
-    @patch("pranaam.utils.requests.Session")
-    @patch("pranaam.utils.tqdm")
-    def test_network_error_logging(
-        self, mock_tqdm: Mock, mock_session: Mock, mock_logger: Mock
-    ) -> None:
-        """Test that network errors are logged properly."""
-        mock_session_instance = Mock()
-        mock_session_instance.get.side_effect = requests.exceptions.ConnectionError(
-            "Network error"
-        )
-        mock_session.return_value.__enter__.return_value = mock_session_instance
-        mock_tqdm.return_value.__enter__.return_value = Mock()
-
-        import tempfile
-
-        with tempfile.TemporaryDirectory() as temp_dir:
-            download_file("http://test.com", temp_dir, "test")
-
-        mock_logger.error.assert_called()
-        args, kwargs = mock_logger.error.call_args
-        assert "Network error downloading models" in args[0]
-
-    @patch("pranaam.utils.logger")
-    @patch("pranaam.utils.requests.Session")
-    @patch("pranaam.utils._safe_extract_tar")
-    @patch("builtins.open", new_callable=mock_open)
-    @patch("pranaam.utils.tqdm")
-    def test_extraction_error_logging(
-        self,
-        mock_tqdm: Mock,
-        mock_file: Mock,
-        mock_extract: Mock,
-        mock_session: Mock,
-        mock_logger: Mock,
-    ) -> None:
-        """Test that extraction errors are logged properly."""
-        # Setup successful download
-        mock_response = Mock()
-        mock_response.headers = {"Content-Length": "1000"}
-        mock_response.iter_content.return_value = [b"chunk"]
-        mock_response.status_code = 200
-        mock_response.raise_for_status.return_value = None
-
-        mock_session_instance = Mock()
-        mock_session_instance.get.return_value = mock_response
-        mock_session.return_value.__enter__.return_value = mock_session_instance
-
-        # Mock tqdm context manager
-        mock_tqdm.return_value.__enter__.return_value.update = Mock()
-
-        # Setup extraction failure
-        mock_extract.side_effect = tarfile.TarError("Extraction failed")
-
-        download_file("http://test.com", "/tmp", "test")
-
-        mock_logger.error.assert_called()
-        args, kwargs = mock_logger.error.call_args
-        assert "File extraction error" in args[0]
+        with pytest.raises(tarfile.TarError):
+            _safe_extract_tar(archive_path, tmp_path / "target")

--- a/uv.lock
+++ b/uv.lock
@@ -430,25 +430,29 @@ name = "cryptography"
 version = "50.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9", size = 880201, upload-time = "2026-07-31T14:25:10.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/57/ef/8f2df13c7216bcad3e1c74e07f6e193d93e998e114f524a53877c9af27ad/cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645", size = 4719554, upload-time = "2026-07-31T14:23:35.611Z" },
     { url = "https://files.pythonhosted.org/packages/d9/41/029086c34d91052fc3b88bcc8056f709a7c915c7a23b235a54eb800b1c97/cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7", size = 4702130, upload-time = "2026-07-31T14:23:37.635Z" },
     { url = "https://files.pythonhosted.org/packages/7d/ff/b6ce0954962e7f7b969f850a883744197bb3910bdfd7b6da162eab7d9f68/cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3", size = 4725244, upload-time = "2026-07-31T14:23:39.471Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1e/63a1027cb7fec360a182208e1b7767d5aa1fe57be3d6aa856e69a321edc0/cryptography-50.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f", size = 5342265, upload-time = "2026-07-31T14:23:41.286Z" },
     { url = "https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae", size = 4734609, upload-time = "2026-07-31T14:23:43.139Z" },
     { url = "https://files.pythonhosted.org/packages/15/37/36a9c479bbe49acea2636c7fd3360d20f7b7e079c300352011c44850b181/cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a", size = 4356517, upload-time = "2026-07-31T14:23:44.939Z" },
     { url = "https://files.pythonhosted.org/packages/32/98/8a151d64367204cbc63ec65d37502f1d9c53cf4bfc6ec3c532614dbec60d/cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987", size = 4724529, upload-time = "2026-07-31T14:23:46.93Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f6/ec13b470172126464a86bf54d2294a46d29837fc51ba3e45d4047946fb5e/cryptography-50.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169", size = 5299852, upload-time = "2026-07-31T14:23:48.851Z" },
     { url = "https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f", size = 4734462, upload-time = "2026-07-31T14:23:50.861Z" },
     { url = "https://files.pythonhosted.org/packages/ca/dc/bd72b26be8953f80625f63151efd38eee71c76ca6cf591c08ff34615a79e/cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105", size = 4852708, upload-time = "2026-07-31T14:23:52.715Z" },
     { url = "https://files.pythonhosted.org/packages/27/20/c930314a2ab476d15dec966ec87e2e9637bb02b06106b12c0396c57bb603/cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef", size = 5004179, upload-time = "2026-07-31T14:23:54.887Z" },
     { url = "https://files.pythonhosted.org/packages/ff/c6/7a6202a534e32103a285b7834a120869557fe198d51d7cfe59754c8bda9c/cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3", size = 4745252, upload-time = "2026-07-31T14:24:26.118Z" },
     { url = "https://files.pythonhosted.org/packages/85/4f/0fa8c2f4428198f15d9ff8d63400e27afbf94ce833f6108da1eb3753f945/cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f", size = 4728939, upload-time = "2026-07-31T14:24:27.994Z" },
     { url = "https://files.pythonhosted.org/packages/d1/63/54dd723490ba2dc09b299682c10b38db38f159728bcaae8c591b8af2f22d/cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5", size = 4748483, upload-time = "2026-07-31T14:24:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/7c77d26285cc7f6991efce64a0f5b4f9383bfa5dd8c5033003eaf7db4cdb/cryptography-50.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f", size = 5367599, upload-time = "2026-07-31T14:24:32.457Z" },
     { url = "https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025", size = 4762647, upload-time = "2026-07-31T14:24:34.599Z" },
     { url = "https://files.pythonhosted.org/packages/be/f3/f9a0173b139372c3a48ed98154b45cc6b9de17c789d5ab552e621c293609/cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a", size = 4385197, upload-time = "2026-07-31T14:24:36.647Z" },
     { url = "https://files.pythonhosted.org/packages/d8/36/83bb81f6e569bc38e1e4a7bc80f29b46bb9601920bc455fc8e888f5d5742/cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b", size = 4748095, upload-time = "2026-07-31T14:24:39.493Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/16/d3008eff98c764979865834c3d386d4fd041b5f52e7f34fc29ac1a5eb515/cryptography-50.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708", size = 5325948, upload-time = "2026-07-31T14:24:41.556Z" },
     { url = "https://files.pythonhosted.org/packages/9c/f8/d97f9603efda3888187bfdb893f26c41be4735c10631d05d284ee6b047c4/cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47", size = 4762400, upload-time = "2026-07-31T14:24:43.636Z" },
     { url = "https://files.pythonhosted.org/packages/64/a2/4615c8f7d81a00b1d6e6afe19f694e1543582349fb5f4076f6cb5dc36485/cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9", size = 4878208, upload-time = "2026-07-31T14:24:45.522Z" },
     { url = "https://files.pythonhosted.org/packages/d2/1a/efcfb02f91407149a0dacffffab791f7e19bf6385f63b3666dc8b5e5c9c8/cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7", size = 5037050, upload-time = "2026-07-31T14:24:47.697Z" },
@@ -820,7 +824,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -1870,7 +1874,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1931,8 +1935,10 @@ name = "pranaam"
 version = "0.5.0"
 source = { editable = "." }
 dependencies = [
+    { name = "filelock" },
     { name = "numpy" },
     { name = "pandas" },
+    { name = "platformdirs" },
     { name = "requests" },
     { name = "rich" },
     { name = "tensorflow" },
@@ -1980,6 +1986,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "filelock", specifier = ">=3.20.0,<4.0.0" },
     { name = "furo", marker = "extra == 'docs'", specifier = ">=2024.1.29" },
     { name = "ipykernel", marker = "extra == 'docs'", specifier = ">=6.0" },
     { name = "jupyter", marker = "extra == 'docs'", specifier = ">=1.0" },
@@ -1988,6 +1995,7 @@ requires-dist = [
     { name = "nbsphinx", marker = "extra == 'docs'", specifier = ">=0.9" },
     { name = "numpy", specifier = ">=1.21.0" },
     { name = "pandas", specifier = ">=1.5.0" },
+    { name = "platformdirs", specifier = ">=4.0.0,<5.0.0" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "scikit-learn", marker = "extra == 'streamlit'", specifier = ">=1.0.0,<2.0.0" },
@@ -2607,8 +2615,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- move model storage from the installed package into the platform user cache
- verify both `.keras` files against pinned SHA-256 digests before install and reuse
- serialize concurrent downloads with a cross-process file lock
- download and extract in a temporary directory, then swap the verified bundle into place
- restore a previous bundle after an interrupted or failed directory swap
- preserve a verified cache when a forced refresh fails
- make the model integration workflow require a repository-owned `PRANAAM_MODEL_URL` secret

## Validation

- 74 unit tests passed; 91.1% line coverage
- cache concurrency, WAF challenge, truncation, checksum mismatch, rollback, and recovery regressions pass
- deptry, Ruff check/format, and mypy passed
- offline Sphinx build passed with warnings treated as errors
- wheel and sdist passed `twine check --strict`

## Remaining deployment action

The authoritative Dataverse endpoint currently returns an empty HTTP 202 AWS WAF challenge to automated clients. This PR intentionally keeps it as the local-user fallback and does not invent an unverified mirror. To activate clean-cache integration, upload the original archive to a trusted host and set the repository Actions secret `PRANAAM_MODEL_URL` to that URL.