### PR TITLE
Prepare 0.6.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
           name: dist
           path: dist/
       - name: Publish (trusted publishing, PEP 740 attestations)
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           attestations: true
+          skip-existing: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   at a pinned `gojiberries/pranaam` Hugging Face revision.
 * Cache English and Hindi models independently for thread-safe language
   switching.
+* Batch predictions to keep inference memory bounded on large datasets.
 * Make `latest=True` refresh an already loaded language model.
 * Repair the command-line entry point and test the Streamlit interface.
 * Adopt the py-canon package, CI, documentation, and release structure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.6.0 - 2026-08-16
+
 * Correct probability reporting by using the model's calibrated output directly.
 * Verify downloaded model files and store them in the user cache.
 * Replace the TensorFlow runtime with parity-tested PyTorch safetensors hosted

--- a/Citation.cff
+++ b/Citation.cff
@@ -10,8 +10,8 @@ authors:
   given-names: "Gaurav"
   email: "gsood07@gmail.com"
 title: "pranaam: Predict religion from names"
-version: 0.2.0
-date-released: 2024-12-03
+version: 0.6.0
+date-released: 2026-08-16
 url: "https://github.com/appeler/pranaam"
 repository-code: "https://github.com/appeler/pranaam"
 repository-artifact: "https://pypi.org/project/pranaam/"

--- a/docs/examples/performance_benchmarks.ipynb
+++ b/docs/examples/performance_benchmarks.ipynb
@@ -33,8 +33,7 @@
     "import pranaam\n",
     "from pranaam.naam import Naam\n",
     "\n",
-    "print(f\"Pranaam version: {pranaam.__version__ if hasattr(pranaam, '__version__') else 'latest'}\")\n",
-    "print(f\"TensorFlow backend loaded: {hasattr(Naam, 'model')}\")"
+    "print(f\"Pranaam version: {pranaam.__version__ if hasattr(pranaam, '__version__') else 'latest'}\")"
    ]
   },
   {
@@ -253,7 +252,7 @@
     "\n",
     "print(\"\\n🔄 Language Switching Insights:\")\n",
     "print(\"• Each language requires its own model (~3-5s load time)\")\n",
-    "print(\"• No cross-language caching - models are swapped out\")\n",
+    "print(\"• English and Hindi models are cached after their first use\")\n",
     "print(\"• The first use of each language incurs one load\")\n",
     "print(\"• Best practice: Process all names in one language before switching\")"
    ]

--- a/pranaam/naam.py
+++ b/pranaam/naam.py
@@ -15,6 +15,8 @@ from .model import ModelConfig, NameClassifier, NameTokenizer, load_classifier
 
 logger = get_logger()
 
+PREDICTION_BATCH_SIZE = 1024
+
 
 def is_english(text: str) -> bool:
     """Return whether text contains only ASCII characters."""
@@ -27,8 +29,13 @@ class _LanguageModel:
     tokenizer: NameTokenizer
 
     def predict(self, names: list[str]) -> np.ndarray:
-        token_ids = self.tokenizer.encode(names)
-        return self.classifier.predict_proba(token_ids).cpu().numpy()
+        probabilities = []
+        for start in range(0, len(names), PREDICTION_BATCH_SIZE):
+            token_ids = self.tokenizer.encode(
+                names[start : start + PREDICTION_BATCH_SIZE]
+            )
+            probabilities.append(self.classifier.predict_proba(token_ids).cpu().numpy())
+        return np.concatenate(probabilities, axis=0)
 
 
 class Naam(Base):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,9 @@ source = "uv-dynamic-versioning"
 [tool.hatch.build.targets.wheel]
 packages = ["pranaam"]
 
+[tool.hatch.build.targets.sdist]
+exclude = ["/.claude", "/CLAUDE.local.md"]
+
 [tool.uv-dynamic-versioning]
 vcs = "git"
 style = "pep440"

--- a/streamlit/requirements.txt
+++ b/streamlit/requirements.txt
@@ -1,1 +1,1 @@
--e ..[streamlit]
+-e .[streamlit]

--- a/tests/test_naam.py
+++ b/tests/test_naam.py
@@ -8,8 +8,9 @@ from unittest.mock import Mock, call, patch
 import numpy as np
 import pandas as pd
 import pytest
+import torch
 
-from pranaam.naam import Naam, is_english
+from pranaam.naam import Naam, _LanguageModel, is_english
 
 
 @pytest.mark.parametrize(
@@ -25,6 +26,42 @@ from pranaam.naam import Naam, is_english
 def test_is_english(text: str, expected: bool) -> None:
     """ASCII-only detection handles English, Hindi, mixed, and empty text."""
     assert is_english(text) is expected
+
+
+@patch("pranaam.naam.PREDICTION_BATCH_SIZE", 2)
+def test_language_model_batches_predictions() -> None:
+    """Inference keeps model inputs bounded and preserves their order."""
+    tokenizer = Mock()
+    tokenizer.encode.side_effect = [
+        torch.tensor([[0], [1]]),
+        torch.tensor([[2], [3]]),
+        torch.tensor([[4]]),
+    ]
+    classifier = Mock()
+    classifier.predict_proba.side_effect = [
+        torch.tensor([[0.9, 0.1], [0.8, 0.2]]),
+        torch.tensor([[0.7, 0.3], [0.6, 0.4]]),
+        torch.tensor([[0.5, 0.5]]),
+    ]
+    model = _LanguageModel(classifier=classifier, tokenizer=tokenizer)
+
+    probabilities = model.predict(["one", "two", "three", "four", "five"])
+
+    assert tokenizer.encode.call_args_list == [
+        call(["one", "two"]),
+        call(["three", "four"]),
+        call(["five"]),
+    ]
+    np.testing.assert_allclose(
+        probabilities,
+        [
+            [0.9, 0.1],
+            [0.8, 0.2],
+            [0.7, 0.3],
+            [0.6, 0.4],
+            [0.5, 0.5],
+        ],
+    )
 
 
 @patch.object(Naam, "_model_for")

--- a/tests/test_streamlit.py
+++ b/tests/test_streamlit.py
@@ -13,6 +13,15 @@ from streamlit.testing.v1 import AppTest
 PROJECT_ROOT = Path(__file__).parents[1]
 
 
+def test_streamlit_requirements_target_repository_root() -> None:
+    """The deployment requirements resolve the editable project from repo root."""
+    requirement = (PROJECT_ROOT / "streamlit" / "requirements.txt").read_text().strip()
+    editable, target = requirement.split(maxsplit=1)
+
+    assert editable == "-e"
+    assert (PROJECT_ROOT / target.split("[", 1)[0]).resolve() == PROJECT_ROOT
+
+
 def test_manual_app_flow_preserves_mixed_input_and_exposes_download(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- date the changelog for the 0.6.0 release
- prepare the merged PyTorch and Hugging Face migration for tagging

## Impact

The package version remains derived from Git tags. Merging this PR prepares
`main` for the `v0.6.0` tag; the tag-triggered trusted publishing workflow will
build, attest, and upload the release to PyPI.

## Validation

- `make ci`: 86 passed, 97.81% coverage
- `make docs`: warning-strict Sphinx build passed
- `preen check . --strict`: all checks passed
- `zizmor --min-severity high`: no findings
- `uv build`
- `twine check --strict`: source distribution and wheel passed
- all shipped external documentation links returned HTTP 200
