### PR TITLE
Cite the version this package actually is

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,8 +10,8 @@ authors:
   given-names: "Gaurav"
   email: "gsood07@gmail.com"
 title: "Pranaam: Calibrated name-pattern estimates"
-version: 0.8.0
-date-released: 2026-08-17
+version: 0.9.0
+date-released: 2026-08-19
 url: "https://github.com/appeler/pranaam"
 repository-code: "https://github.com/appeler/pranaam"
 repository-artifact: "https://pypi.org/project/pranaam/"


### PR DESCRIPTION
`CITATION.cff` recorded version `0.8.0`; `project.version` is `0.9.0`. Whoever cites this package copies that number, so a stale one outlives the release in someone else's bibliography.


Found by `preen check` sweeping the fleet — this repo was one of eight — and applied with `preen fix citation`, which also moves `date-released` to the date of the tag naming the release rather than leaving a right version beside a wrong date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SkMDqnEFUgr7Mbc1HwMqX