### PR TITLE
Configure pytest to fail on what it should fail on

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,20 +87,17 @@ email = "gsood07@gmail.com"
 [tool.pytest.ini_options]
 python_files = "test_*.py"
 testpaths = ["tests"]
-addopts = [
-    "-v",
-    "--tb=short",
-    "--strict-markers",
-    "--disable-warnings",
-    "--cov=pranaam",
-    "--cov-report=term-missing",
-]
+addopts = ["-v", "--tb=short", "--strict-markers", "--disable-warnings", "--cov=pranaam", "--cov-report=term-missing", "--strict-config", "-ra"]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests as integration tests (requires model download)",
     "unit: marks tests as unit tests",
     "e2e: marks tests as end-to-end tests with real models"
 ]
+minversion = "6"
+log_level = "INFO"
+xfail_strict = true
+filterwarnings = ["error"]
 
 
 


### PR DESCRIPTION
py-canon 1.3.0 puts the whole sp-repo-review PP301–PP309 set in the template, and preen's `pytest-config` check now gates on it.

```toml
minversion, log_level, xfail_strict, filterwarnings = ["error"]
addopts: -ra, --strict-config, --strict-markers
```

These decide whether a run **fails**, not how it reads. Without `filterwarnings` a dependency's DeprecationWarning stays invisible until the release that removes the API; without `--strict-markers` a typo in a marker name selects nothing and reports success; without `--strict-config` a typo in this very table is ignored.

Applied with `preen fix pytest-config`. **The suite was run under the new settings before this was opened** — the whole point is that warnings now fail, so a config that quietly breaks the suite would defeat the purpose. Anything that needed a scoped ignore or a real fix got one, and is described above if so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)